### PR TITLE
Fix gzip trailer on big endian hosts

### DIFF
--- a/lib/Plack/Middleware/Deflater.pm
+++ b/lib/Plack/Middleware/Deflater.pm
@@ -141,7 +141,7 @@ sub print : method {
         if ( !$self->{header} && $self->{encoding} eq 'gzip' ) {
             $buf = pack("nccVcc",GZIP_MAGIC,Z_DEFLATED,0,time(),0,$Compress::Raw::Zlib::gzip_os_code) . $buf
         }
-        $buf .= pack("LL", $self->{crc},$self->{length}) if $self->{encoding} eq 'gzip';
+        $buf .= pack("VV", $self->{crc},$self->{length}) if $self->{encoding} eq 'gzip';
         $self->{closed} = 1;
         return $buf;
     }


### PR DESCRIPTION
These values need to be stored as little endian regardless
of the host endianness.

Bug-Debian: https://bugs.debian.org/893472